### PR TITLE
Add golangci-lint to workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,5 +21,10 @@ jobs:
       with:
         go-version: '1.22'
 
+    - name: Lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: 'latest'
+
     - name: Test
       run: go test -v ./...

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 func path(s string) *filter.Path {
 	p, err := filter.ParsePath([]byte(s))
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Failed to parse %s occurred by %s", s, err))
+		fmt.Printf("Failed to parse %s occurred by %s\n", s, err)
 	}
 	return &p
 }


### PR DESCRIPTION
By introducing a linter into your project, you can reduce the cost of code checking. The golangci-lint we will introduce this time is a tool that runs linters at high speed and is well known in the Go community.

The default linter is here: https://golangci-lint.run/usage/linters/#enabled-by-default

---

(Copilot summary)

This pull request includes two primary changes aimed at enhancing the Go project's workflow and improving the code quality. The first change introduces a new linting step in the GitHub Actions workflow for the Go project, ensuring code quality before any merge. The second change is a modification in the `main_test.go` file, where the error handling and logging have been improved for better readability and efficiency.

Enhancements in workflow:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR24-R28): A new linting step has been added to the GitHub Actions workflow using `golangci-lint-action@v6`. This step will run with the latest version of the linter, ensuring the code adheres to the Go best practices before any merge.

Code quality improvements:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL16-R16): The error logging in the `path` function has been improved. Instead of using `fmt.Println` combined with `fmt.Sprintf`, it now uses `fmt.Printf` for better efficiency and readability.